### PR TITLE
Enable alternative architectures

### DIFF
--- a/config.php
+++ b/config.php
@@ -50,3 +50,16 @@ $development_repos = array(
     'testing',
     'nethforge-testing',
 );
+
+
+// Alternative architectures:
+// - stable goes to mirror,
+// - development goes to packages.nethserver.org
+$stable_arches = array(
+    'x86_64',
+);
+
+$development_arches = array(
+    'armv7hl',
+    'aarch64',
+);

--- a/config.php
+++ b/config.php
@@ -60,6 +60,6 @@ $stable_arches = array(
 );
 
 $development_arches = array(
-    'armv7hl',
+    'armhfp',
     'aarch64',
 );

--- a/nethserver.php
+++ b/nethserver.php
@@ -44,6 +44,11 @@ $ce_repos = array(
     'ce-extras' => 'extras',
 );
 
+// Remap machine architecture to repo architecture:
+if($arch == 'armv7hl') {
+    $arch = 'armhfp';
+}
+
 $valid_release = in_array($release, array_keys($stable_releases));
 $valid_nsrelease = in_array($nsrelease, array_merge($stable_releases, $development_releases, $vault_releases)) && ($nsrelease[0] == $release[0]);
 $valid_arch = in_array($arch, array_merge($stable_arches, $development_arches));

--- a/nethserver.php
+++ b/nethserver.php
@@ -46,7 +46,7 @@ $ce_repos = array(
 
 $valid_release = in_array($release, array_keys($stable_releases));
 $valid_nsrelease = in_array($nsrelease, array_merge($stable_releases, $development_releases, $vault_releases)) && ($nsrelease[0] == $release[0]);
-$valid_arch = in_array($arch, array('x86_64'));
+$valid_arch = in_array($arch, array_merge($stable_arches, $development_arches));
 $valid_repo = in_array($repo, array_merge($ns_repos,array_keys($ce_repos)));
 
 if( ! $valid_release || ! $valid_arch || ! $valid_repo ) {
@@ -62,7 +62,10 @@ if ( ! $valid_nsrelease ) {
 header('Content-type: text/plain; charset=UTF-8');
 
 $served_by_nethserver_mirrors = in_array($repo, $ns_repos)
-  && ! (in_array($nsrelease, $vault_releases) || in_array($repo, $development_repos) || in_array($nsrelease, $development_releases))
+  && ! (in_array($nsrelease, $vault_releases)
+        || in_array($repo, $development_repos)
+        || in_array($nsrelease, $development_releases)
+        || in_array($arch, $development_arches))
 ;
 
 if($served_by_nethserver_mirrors) {


### PR DESCRIPTION
Serve alternative architectures YUM repositories from packages.nethserver.org

Applies to

-    'base',
-    'updates',
-    'testing',
-    'nethforge',
-    'nethforge-testing'

Test by overriding mirrorlist.nethserver.org in /etc/hosts, then run:

    curl -v 'http://mirrorlist.nethserver.org/?release=7&repo=base&arch=armv7hl&nsrelease='