### PR TITLE
Serve SCLo repos from CentOS mirror infra

### DIFF
--- a/nethserver.php
+++ b/nethserver.php
@@ -42,6 +42,8 @@ $ce_repos = array(
     'ce-base' => 'os',
     'ce-updates' => 'updates',
     'ce-extras' => 'extras',
+    'ce-sclo-sclo' => 'sclo-sclo',
+    'ce-sclo-rh' => 'sclo-rh',
 );
 
 // Remap machine architecture to repo architecture:


### PR DESCRIPTION
The SCLo repositories are available from CentOS mirrors and are also
served by mirrorlist.centos.org.

See also https://lists.centos.org/pipermail/centos-devel/2018-September/016949.html

https://github.com/NethServer/dev/issues/5689