### PR TITLE
New mirrors file format with CC prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ If you want to host a NethServer mirror
 * Read the community [HowTo](https://community.nethserver.org/t/how-to-create-your-own-nethserver-mirror/344)
 * Edit [mirrors](https://github.com/NethServer/mirrorlist/edit/master/mirrors)
 
+The `mirrors` file format follows these rules:
+
+1. each line represents a mirror record
+2. the line begins with the two letters country code where the mirror is 
+   located, followed by a single space separator (e.g. `us `)
+3. the line continues with the base mirror URL (e.g. `http://mirror.nethserver.org/nethserver/`)
+
 ## Mirror status
 
 A couple of `mirmon` instances run on `mirror-status.nethserver.org`:

--- a/mirrors
+++ b/mirrors
@@ -1,18 +1,18 @@
-http://mirror.nethserver.org/nethserver
-http://mirror1.nethserver.org/nethserver
-https://mirror.nethesis.it/nethserver
-http://nethserver.de-labrusse.fr
-http://mirror.framassa.org/nethserver
-http://mirror.nordest.systems/nethserver
-https://mirror.alpix.eu/nethserver
-http://mrmarkuz.goip.de/mirror/nethserver
-https://mirror.pcxlan.es/nethserver
-https://markusneuberger.at/mirror/nethserver
-http://buck.goip.de/nethserver
-http://mrmarkuz.dynu.net/nethserver
-http://server.liftingtrade.hu/nethserver
-http://ketrax.eu/nethserver
-http://ns-mirror1.ibi.net.br
-http://ns-mirror2.ibi.net.br
-http://ns-mirror3.ibi.net.br
-http://nethserver.interlin.nl/nethserver
+us http://mirror.nethserver.org/nethserver/
+nl http://mirror1.nethserver.org/nethserver/
+it https://mirror.nethesis.it/nethserver/
+fr http://nethserver.de-labrusse.fr/
+fr http://mirror.framassa.org/nethserver/
+fr http://mirror.nordest.systems/nethserver/
+de https://mirror.alpix.eu/nethserver/
+at http://mrmarkuz.goip.de/mirror/nethserver/
+es https://mirror.pcxlan.es/nethserver/
+at https://markusneuberger.at/mirror/nethserver/
+at http://buck.goip.de/nethserver/
+de http://mrmarkuz.dynu.net/nethserver/
+hu http://server.liftingtrade.hu/nethserver/
+hu http://ketrax.eu/nethserver/
+br http://ns-mirror1.ibi.net.br/
+br http://ns-mirror2.ibi.net.br/
+br http://ns-mirror3.ibi.net.br/
+de http://nethserver.interlin.nl/nethserver/

--- a/nethserver.php
+++ b/nethserver.php
@@ -80,7 +80,8 @@ $served_by_nethserver_mirrors = in_array($repo, $ns_repos)
 ;
 
 if($served_by_nethserver_mirrors) {
-    $mirrors = file("mirrors");
+    // trim leading CC-prefix and trailing slash:
+    $mirrors = preg_replace('/(^\w\w|\/$)/', '', file("mirrors"));
 } elseif (in_array($repo, array_keys($ce_repos))) {
     // map to real repository name, extracting the $repo_suffix (required by SCLo):
     list($repo, $repo_suffix) = array_merge(explode('-', $ce_repos[$repo], 2), array(''));


### PR DESCRIPTION
This new file format is consumed by mirmon and allows to automatically update http://mirror-status.nethserver.org/