### PR TITLE
Fix NS installation on CentOS minimal

### DIFF
--- a/nethserver.php
+++ b/nethserver.php
@@ -56,9 +56,10 @@ if($arch == 'armv7hl') {
     $arch = 'armhfp';
 }
 
-// Assign to nsrelease a default full stable release number, required by
-// legacy/unlocked clients that do not send it:
-if( ! $nsrelease) {
+// Assign to $nsrelease a default full stable release number. This is required
+// by legacy/unlocked clients and plain CentOS installations that do not send
+// $nsrelease properly:
+if( ! preg_match("/^${release}\./", $nsrelease)) {
     $nsrelease = array_shift(preg_grep("/^${release}\./", $stable_releases));
 }
 


### PR DESCRIPTION
A CentOS minimal installation does not have `/etc/yum/vars/nsrelease` at all, thus YUM sends the placeholder `$nsrelease` as-is.

The PHP script must deal with both the empty string and `$nsrelease`. Anything that does not looks like a version number is treated as NULL and a fallback version number is forcibly assigned.

NethServer/dev#5704