### PR TITLE
Add $development_releases list with 7.7.1908

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ CentOS repositories.
 
 Use cases and configuration editing rules:
 
-- Edit ``$stable_releases`` only when NethServer releases a new version and our
-  mirrors are synched.
+- When both a new CentOS has been released and NethServer development release is
+  available, edit ``$development_releases``.
+
+- Move a ``$development_releases`` to ``$stable_releases`` only when NethServer
+  releases a new stable version and our mirrors are synched.
 
 - When a CentOS release goes to vault, list that release number under
   ``$vault_releases``. At that point it can be removed from NethServer mirrors

--- a/config.php
+++ b/config.php
@@ -26,6 +26,11 @@ $stable_releases = array(
     '7.6.1810',
 );
 
+// Other valid version numbers served by mirror.nethserver.org
+$development_releases = array(
+    '7.7.1908',
+);
+
 $ce_mirror_countries = array(
     'au' => 1,
     'br' => 1,
@@ -37,8 +42,7 @@ $ce_mirror_countries = array(
 );
 
 // Upstream versions served by vault.centos.org. It implies the same NethServer
-// releases aren't served by NethServer mirrors any more. Add the release
-// numbers here to prevent undesired upgrades when yum-cron runs.
+// releases are not served by NethServer mirrors any more.
 $vault_releases = array(
     '7.5.1804',
 );

--- a/nethserver.php
+++ b/nethserver.php
@@ -65,7 +65,7 @@ if( ! preg_match("/^${release}\./", $nsrelease)) {
 
 $major_releases = array_unique(preg_replace('/^(\d).*/', '$1', $stable_releases));
 $valid_release = in_array($release, $major_releases);
-$valid_nsrelease = in_array($nsrelease, array_merge($stable_releases, $vault_releases)) && ($nsrelease[0] == $release[0]);
+$valid_nsrelease = in_array($nsrelease, array_merge($stable_releases, $vault_releases, $development_releases)) && ($nsrelease[0] == $release[0]);
 $valid_arch = in_array($arch, array_merge($stable_arches, $development_arches));
 $valid_repo = in_array($repo, array_merge($ns_repos,array_keys($ce_repos)));
 
@@ -79,7 +79,7 @@ if( ! $valid_release || ! $valid_arch || ! $valid_repo || ! $valid_nsrelease ) {
 
 
 $served_by_nethserver_mirrors = in_array($repo, $ns_repos)
-  && ! (in_array($nsrelease, $vault_releases)
+  && ! (in_array($nsrelease, array_merge($vault_releases, $development_releases))
         || in_array($repo, $development_repos)
         || in_array($arch, $development_arches))
 ;


### PR DESCRIPTION
I want to revert the variable deletion because we need it during the new release QA phase. 

A development release number is a valid upstream release number that is
not served by our mirrors. In other words it defines a new upstream
release number.

https://github.com/NethServer/dev/issues/5831