### PR TITLE
Add 7.8.2003 as development version

### DIFF
--- a/config.php
+++ b/config.php
@@ -28,6 +28,7 @@ $stable_releases = array(
 
 // Other valid version numbers served by mirror.nethserver.org
 $development_releases = array(
+    '7.8.2003',
 );
 
 $ce_mirror_countries = array(


### PR DESCRIPTION
This PR allows to point a client to YUM repositories for NS version 7.8.2003.

The following commands are required to switch to the development version of 7.8:

```text
# mkdir -p /etc/e-smith/templates-custom/etc/yum/vars/nsrelease
# echo 7.8.2003 > /etc/e-smith/templates-custom/etc/yum/vars/nsrelease/50output
# signal-event software-repos-save
```

https://github.com/NethServer/dev/issues/6144