### PR TITLE
Serve aarch64 SCLo repos from upstream mirrors

### DIFF
--- a/nethserver.php
+++ b/nethserver.php
@@ -97,10 +97,6 @@ if($served_by_nethserver_mirrors) {
         $repo = 'empty';
         $repo_suffix = '';
         $mirrors = array('http://mirror.nethserver.org/nethserver');
-    } elseif($repo == 'sclo' && $repo_suffix == 'sclo' && $arch == 'aarch64') {
-        $repo = 'empty';
-        $repo_suffix = '';
-        $mirrors = array('http://mirror.nethserver.org/nethserver');
     } elseif(in_array($nsrelease, $vault_releases)) {
         // CentOS versions served by vault.centos.org
         if($arch == 'x86_64') {


### PR DESCRIPTION
This PR enable CentOS aarch64 SCLo-sclo repositories, as asked by @markVnl in the community forum.

IIUC, SCLo-rh for aarch64 are already served by official CentOS `altarch` repositories.

SCLo packages for the armhfp arch are still built by Mark and uploaded to `arm-updates`.

https://community.nethserver.org/t/building-rh-php73-for-arm-32bit/17479/18?u=davidep