### PR TITLE
Redirect to Rocky Linux mirrors

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,5 +6,8 @@ RewriteRule "^cron" /error [L]
 RewriteRule "^(\d[\d\.]*)/centos$" /centos.php/$1/ [END]
 RewriteRule "^(\d[\d\.]*)/nethserver$" /nethserver.php/$1/ [END]
 
+RewriteCond %{REQUEST_URI} ^/rockylinux
+RewriteRule ^rockylinux.*$ https://mirrors.rockylinux.org/mirrorlist [L,QSA]
+
 RewriteCond %{QUERY_STRING} "repo="
 RewriteRule "^$" /nethserver.php [END]


### PR DESCRIPTION
Redirect any request starting with `/rockylinux` to Rocky Linux mirrors.

This is a temporary redirect for NS8 community repositories.

See also
- https://github.com/NethServer/ns8-core/pull/523
- https://trello.com/c/fb2Msk7G/456-core-p0-nethserver-yum-repository