### PR TITLE
Mirrorlist redirect to u4.nethesis.it for NS8

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ RewriteRule "^(\d[\d\.]*)/centos$" /centos.php/$1/ [END]
 RewriteRule "^(\d[\d\.]*)/nethserver$" /nethserver.php/$1/ [END]
 
 RewriteCond %{REQUEST_URI} ^/rockylinux
-RewriteRule ^rockylinux.*$ https://mirrors.rockylinux.org/mirrorlist [L,QSA]
+RewriteRule ^rockylinux.*$ https://u4.nethesis.it/mirrorlist [L,QSA]
 
 RewriteCond %{QUERY_STRING} "repo="
 RewriteRule "^$" /nethserver.php [END]


### PR DESCRIPTION
Refs https://github.com/NethServer/dev/issues/6789


Example query: https://u4.nethesis.it/mirrorlist?arch=x86_64&repo=BaseOS-9

Full metadata URL https://u4.nethesis.it/rocky/9/BaseOS/x86_64/os/repodata/repomd.xml