### PR TITLE
Set mrmarkuz.goip.de to https

### DIFF
--- a/mirrors
+++ b/mirrors
@@ -2,7 +2,7 @@ us http://mirror.nethserver.org/nethserver/
 fr http://nethserver.de-labrusse.fr/
 de http://mirror.framassa.org/nethserver/
 de https://mirror.alpix.eu/nethserver/
-at http://mrmarkuz.goip.de/mirror/nethserver/
+at https://mrmarkuz.goip.de/mirror/nethserver/
 es https://mirror.pcxlan.es/nethserver/
 at https://markusneuberger.at/mirror/nethserver/
 at http://buck.goip.de/nethserver/


### PR DESCRIPTION
I switched to NethSec as firewall solution so I need to use an HTTPS reverse proxy for the mirror.